### PR TITLE
Fix Wrangler build by installing hono dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "colby-recipe-backend",
       "version": "1.1.0",
       "license": "MIT",
+      "dependencies": {
+        "hono": "^4.9.9"
+      },
       "devDependencies": {
         "typescript": "^5.7.2",
         "vitest": "^2.1.3",
@@ -1783,6 +1786,15 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/hono": {
+      "version": "4.9.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.9.tgz",
+      "integrity": "sha512-Hxw4wT6zjJGZJdkJzAx9PyBdf7ZpxaTSA0NfxqjLghwMrLBX8p33hJBzoETRakF3UJu6OdNQBZAlNSkGqKFukw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.3.4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,12 @@
     "migrate:remote": "wrangler d1 migrations apply DB --remote",
     "deploy": "npm run migrate:remote && wrangler deploy"
   },
-  "keywords": ["cloudflare", "workers", "recipes", "ai"],
+  "keywords": [
+    "cloudflare",
+    "workers",
+    "recipes",
+    "ai"
+  ],
   "author": "",
   "license": "MIT",
   "devDependencies": {
@@ -19,5 +24,7 @@
     "vitest": "^2.1.3",
     "wrangler": "^3.96.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "hono": "^4.9.9"
+  }
 }


### PR DESCRIPTION
## Summary
- add the missing hono runtime dependency so the worker bundle resolves its imports

## Testing
- npm run typecheck *(fails: existing TypeScript errors in src/worker.ts unrelated to this change)*
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68df75ecd090832eb506008211590837