### PR TITLE
Add favorites and ratings database helpers

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -725,7 +725,7 @@ function mapRatingRow(row: RatingRow): Rating {
   return {
     userId: row.user_id,
     recipeId: row.recipe_id,
-    stars: Number(row.stars),
+    stars: row.stars,
     notes: row.notes,
     cookedAt: row.cooked_at,
     createdAt: row.created_at,


### PR DESCRIPTION
## Summary
- implement CRUD helpers for user favorites including row mapping utilities
- add rating upsert, retrieval, and listing helpers with shared row mappers

## Testing
- npm run typecheck *(fails: wrangler types no longer supports --experimental-include-runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68e0372e83c4832eb55f1e062b849ebb