### PR TITLE
Add kitchen appliance management and agentic recipe tailoring

### DIFF
--- a/migrations/0003_kitchen_appliances.sql
+++ b/migrations/0003_kitchen_appliances.sql
@@ -1,0 +1,19 @@
+-- Migration: Kitchen appliances management and recipe prep phases
+-- Adds prep phase storage to recipes and a table for user kitchen appliances
+
+ALTER TABLE recipes ADD COLUMN prep_phases_json TEXT;
+
+CREATE TABLE IF NOT EXISTS kitchen_appliances (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  brand TEXT NOT NULL,
+  model TEXT NOT NULL,
+  manual_r2_key TEXT,
+  extracted_text TEXT,
+  manual_embedding_json TEXT,
+  created_at DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  updated_at DATETIME DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_kitchen_appliances_user ON kitchen_appliances(user_id);

--- a/public/index.html
+++ b/public/index.html
@@ -80,6 +80,42 @@
       padding-left: 1.25rem;
     }
 
+    .appliance-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .appliance-list li {
+      background: rgba(148, 163, 184, 0.18);
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .appliance-meta {
+      display: grid;
+      gap: 0.25rem;
+    }
+
+    .appliance-actions {
+      display: flex;
+      gap: 0.5rem;
+    }
+
+    .stack {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
     .tester form {
       display: flex;
       flex-direction: column;
@@ -326,7 +362,74 @@
       <button id="imageBtn">🖼️ Normalize images</button>
       <div id="imageResult" style="margin-top:1rem;"></div>
     </section>
-  
+
+    <section id="appliances">
+      <h2>Kitchen appliances</h2>
+      <p>Upload manuals to personalize recipes for your gear. Manuals are stored securely in R2 and processed asynchronously.</p>
+      <form id="applianceForm" class="stack">
+        <div class="row">
+          <div>
+            <label for="applianceBrand">Brand</label>
+            <input id="applianceBrand" type="text" placeholder="e.g. Breville" required />
+          </div>
+          <div>
+            <label for="applianceModel">Model</label>
+            <input id="applianceModel" type="text" placeholder="e.g. Smart Oven Air" required />
+          </div>
+        </div>
+        <div>
+          <label for="applianceManual">Manual (PDF optional)</label>
+          <input id="applianceManual" type="file" accept="application/pdf" />
+        </div>
+        <div class="row" style="align-items:center; gap:0.75rem;">
+          <button type="submit">➕ Add appliance</button>
+          <button type="button" id="refreshAppliances" class="secondary">🔄 Refresh list</button>
+        </div>
+      </form>
+      <div id="applianceResult" class="response" hidden>
+        <h3>Latest appliance</h3>
+        <pre id="applianceResultBody"></pre>
+      </div>
+      <div>
+        <h3>Your appliances</h3>
+        <ul id="appliancesList" class="appliance-list">
+          <li class="muted">No appliances yet. Add one to get started.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="recipeAgents">
+      <h2>Agentic recipe tailoring</h2>
+      <p>Load structured recipes, generate Mermaid flowcharts, and rewrite instructions for a specific appliance.</p>
+      <div class="row">
+        <div>
+          <label for="tailorRecipeId">Recipe ID</label>
+          <input id="tailorRecipeId" type="text" placeholder="recipe-123" />
+        </div>
+        <div>
+          <label for="tailorApplianceId">Appliance ID</label>
+          <input id="tailorApplianceId" type="text" placeholder="appliance-456" />
+        </div>
+      </div>
+      <div class="row" style="align-items:center; gap:0.75rem;">
+        <button id="loadRecipeDetail" class="secondary">📄 Load recipe detail</button>
+        <button id="flowchartBtn" class="secondary">📈 Generate flowchart</button>
+        <button id="tailorBtn">🤖 Tailor instructions</button>
+      </div>
+      <div id="recipeDetailResult" class="response" hidden>
+        <h3>Recipe detail</h3>
+        <pre></pre>
+      </div>
+      <div id="flowchartResult" class="response" hidden>
+        <h3>Mermaid flowchart</h3>
+        <pre></pre>
+      </div>
+      <div id="tailorResult" class="response" hidden>
+        <h3>Tailored steps</h3>
+        <pre></pre>
+      </div>
+    </section>
+
     <section id="prefs">
       <h2>User preferences</h2>
       <div class="row">
@@ -574,6 +677,25 @@
     const userIdInput = document.getElementById('userId');
     const toolCheckboxes = Array.from(document.querySelectorAll('.toolChk'));
     const themeInput = document.getElementById('theme');
+    const applianceForm = document.getElementById('applianceForm');
+    const applianceBrand = document.getElementById('applianceBrand');
+    const applianceModel = document.getElementById('applianceModel');
+    const applianceManual = document.getElementById('applianceManual');
+    const applianceResult = document.getElementById('applianceResult');
+    const applianceResultBody = document.getElementById('applianceResultBody');
+    const appliancesList = document.getElementById('appliancesList');
+    const refreshAppliances = document.getElementById('refreshAppliances');
+    const recipeDetailResult = document.getElementById('recipeDetailResult');
+    const recipeDetailPre = recipeDetailResult?.querySelector('pre');
+    const flowchartResult = document.getElementById('flowchartResult');
+    const flowchartPre = flowchartResult?.querySelector('pre');
+    const tailorResult = document.getElementById('tailorResult');
+    const tailorPre = tailorResult?.querySelector('pre');
+    const loadRecipeDetailBtn = document.getElementById('loadRecipeDetail');
+    const flowchartBtn = document.getElementById('flowchartBtn');
+    const tailorBtnAgent = document.getElementById('tailorBtn');
+    const tailorRecipeId = document.getElementById('tailorRecipeId');
+    const tailorApplianceId = document.getElementById('tailorApplianceId');
 
     const storageKey = 'menuforge-api-key';
     
@@ -659,6 +781,168 @@
       }
     }
     imageBtn.addEventListener('click', handleImages);
+
+    async function loadAppliancesList() {
+      if (!appliancesList) return;
+      try {
+        refreshAppliances && (refreshAppliances.disabled = true);
+        const data = await callJson('/api/kitchen/appliances', { headers: authHeaders() });
+        const items = data.appliances || [];
+        if (!items.length) {
+          appliancesList.innerHTML = '<li class="muted">No appliances yet. Add one to get started.</li>';
+          return;
+        }
+        appliancesList.innerHTML = items
+          .map((appliance) => {
+            const manualStatus = appliance.extractedText ? 'Manual processed' : 'Awaiting OCR';
+            const manualKey = appliance.manualR2Key ? `Manual key: ${appliance.manualR2Key}` : 'Manual not uploaded';
+            return `
+              <li>
+                <div class="appliance-meta">
+                  <strong>${appliance.brand} ${appliance.model}</strong>
+                  <span class="pill">${manualStatus}</span>
+                  <small>ID: ${appliance.id}</small>
+                  <small>${manualKey}</small>
+                </div>
+                <div class="appliance-actions">
+                  <button data-action="delete" data-id="${appliance.id}" class="secondary">🗑 Remove</button>
+                </div>
+              </li>`;
+          })
+          .join('');
+      } catch (err) {
+        appliancesList.innerHTML = `<li><pre>${err.message}</pre></li>`;
+      } finally {
+        refreshAppliances && (refreshAppliances.disabled = false);
+      }
+    }
+
+    async function handleApplianceSubmit(event) {
+      event.preventDefault();
+      if (!applianceForm) return;
+      try {
+        applianceForm.querySelector('button[type="submit"]').disabled = true;
+        const form = new FormData();
+        form.append('brand', applianceBrand.value.trim());
+        form.append('model', applianceModel.value.trim());
+        if (applianceManual.files && applianceManual.files[0]) {
+          form.append('manual', applianceManual.files[0]);
+        }
+        const res = await fetch('/api/kitchen/appliances', {
+          method: 'POST',
+          headers: authHeaders(),
+          body: form,
+        });
+        const data = await res.json();
+        if (!res.ok) throw new Error(data.error || res.statusText);
+        if (applianceResult && applianceResultBody) {
+          applianceResult.hidden = false;
+          applianceResultBody.textContent = JSON.stringify(data.appliance, null, 2);
+        }
+        applianceForm.reset();
+        await loadAppliancesList();
+      } catch (err) {
+        if (applianceResult && applianceResultBody) {
+          applianceResult.hidden = false;
+          applianceResultBody.textContent = err.message;
+        }
+      } finally {
+        const submitBtn = applianceForm.querySelector('button[type="submit"]');
+        submitBtn && (submitBtn.disabled = false);
+      }
+    }
+
+    async function handleDeleteAppliance(id) {
+      try {
+        await callJson(`/api/kitchen/appliances/${id}`, {
+          method: 'DELETE',
+          headers: authHeaders(),
+        });
+        await loadAppliancesList();
+      } catch (err) {
+        alert(err.message);
+      }
+    }
+
+    appliancesList?.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      const id = target.dataset.id;
+      if (target.dataset.action === 'delete' && id) {
+        handleDeleteAppliance(id);
+      }
+    });
+
+    applianceForm?.addEventListener('submit', handleApplianceSubmit);
+    refreshAppliances?.addEventListener('click', loadAppliancesList);
+
+    async function handleRecipeDetailLoad() {
+      if (!recipeDetailResult || !recipeDetailPre) return;
+      try {
+        loadRecipeDetailBtn.disabled = true;
+        recipeDetailResult.hidden = false;
+        recipeDetailPre.textContent = 'Loading…';
+        const id = tailorRecipeId.value.trim();
+        if (!id) throw new Error('Recipe ID required');
+        const data = await callJson(`/api/recipes/${encodeURIComponent(id)}`, {
+          headers: authHeaders(),
+        });
+        recipeDetailPre.textContent = JSON.stringify(data.recipe, null, 2);
+      } catch (err) {
+        recipeDetailPre.textContent = err.message;
+      } finally {
+        loadRecipeDetailBtn.disabled = false;
+      }
+    }
+
+    loadRecipeDetailBtn?.addEventListener('click', handleRecipeDetailLoad);
+
+    async function handleFlowchart() {
+      if (!flowchartResult || !flowchartPre) return;
+      try {
+        flowchartBtn.disabled = true;
+        flowchartResult.hidden = false;
+        flowchartPre.textContent = 'Loading…';
+        const id = tailorRecipeId.value.trim();
+        if (!id) throw new Error('Recipe ID required');
+        const data = await callJson(`/api/recipes/${encodeURIComponent(id)}/flowchart`, {
+          headers: authHeaders(),
+        });
+        flowchartPre.textContent = data.flowchart || '';
+      } catch (err) {
+        flowchartPre.textContent = err.message;
+      } finally {
+        flowchartBtn.disabled = false;
+      }
+    }
+
+    flowchartBtn?.addEventListener('click', handleFlowchart);
+
+    async function handleTailorRecipe() {
+      if (!tailorResult || !tailorPre) return;
+      try {
+        tailorBtnAgent.disabled = true;
+        tailorResult.hidden = false;
+        tailorPre.textContent = 'Loading…';
+        const recipeId = tailorRecipeId.value.trim();
+        const applianceId = tailorApplianceId.value.trim();
+        if (!recipeId) throw new Error('Recipe ID required');
+        if (!applianceId) throw new Error('Appliance ID required');
+        const data = await callJson(`/api/recipes/${encodeURIComponent(recipeId)}/tailor`, {
+          method: 'POST',
+          headers: authHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify({ appliance_id: applianceId }),
+        });
+        const steps = data.tailored_steps || [];
+        tailorPre.textContent = steps.length ? steps.map((step, index) => `${index + 1}. ${step}`).join('\n') : 'No steps returned.';
+      } catch (err) {
+        tailorPre.textContent = err.message;
+      } finally {
+        tailorBtnAgent.disabled = false;
+      }
+    }
+
+    tailorBtnAgent?.addEventListener('click', handleTailorRecipe);
 
     async function handlePrefsLoad() {
       try {

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Colby Recipe Backend API",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "Programmatic interface for MenuForge recipe ingestion, personalization, and menu planning."
   },
   "servers": [
@@ -44,6 +44,52 @@
           "heroImageUrl": { "type": ["string", "null"] }
         },
         "required": ["id", "title", "tags"]
+      },
+      "Ingredient": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "quantity": { "type": ["string", "null"] },
+          "notes": { "type": ["string", "null"] }
+        },
+        "required": ["name"]
+      },
+      "RecipeStep": {
+        "type": "object",
+        "properties": {
+          "title": { "type": ["string", "null"] },
+          "instruction": { "type": "string" }
+        },
+        "required": ["instruction"]
+      },
+      "PrepPhase": {
+        "type": "object",
+        "properties": {
+          "phaseTitle": { "type": "string" },
+          "ingredients": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Ingredient" }
+          }
+        },
+        "required": ["phaseTitle", "ingredients"]
+      },
+      "KitchenAppliance": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "userId": { "type": "string" },
+          "brand": { "type": "string" },
+          "model": { "type": "string" },
+          "manualR2Key": { "type": ["string", "null"] },
+          "extractedText": { "type": ["string", "null"] },
+          "manualEmbedding": {
+            "type": ["array", "null"],
+            "items": { "type": "number" }
+          },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        },
+        "required": ["id", "userId", "brand", "model", "createdAt", "updatedAt"]
       },
       "ChatIngredientsRequest": {
         "type": "object",
@@ -91,46 +137,35 @@
         "properties": {
           "id": { "type": "string" },
           "title": { "type": "string" },
-          "description": { "type": "string" },
-          "cuisine": { "type": "string" },
+          "description": { "type": ["string", "null"] },
+          "cuisine": { "type": ["string", "null"] },
           "tags": {
             "type": "array",
             "items": { "type": "string" }
           },
-          "heroImageUrl": { "type": "string" },
-          "yield": { "type": "string" },
+          "heroImageUrl": { "type": ["string", "null"] },
+          "yield": { "type": ["string", "null"] },
           "prepTimeMinutes": { "type": ["integer", "null"] },
           "cookTimeMinutes": { "type": ["integer", "null"] },
           "totalTimeMinutes": { "type": ["integer", "null"] },
           "ingredients": {
             "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": { "type": "string" },
-                "quantity": { "type": "string" },
-                "notes": { "type": "string" }
-              },
-              "required": ["name"]
-            }
+            "items": { "$ref": "#/components/schemas/Ingredient" }
           },
           "steps": {
             "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "title": { "type": "string" },
-                "instruction": { "type": "string" }
-              },
-              "required": ["instruction"]
-            }
+            "items": { "$ref": "#/components/schemas/RecipeStep" }
           },
           "tools": {
             "type": "array",
             "items": { "type": "string" }
           },
-          "notes": { "type": "string" },
-          "sourceUrl": { "type": "string" }
+          "notes": { "type": ["string", "null"] },
+          "sourceUrl": { "type": ["string", "null"], "format": "uri" },
+          "prepPhases": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/PrepPhase" }
+          }
         },
         "required": ["id", "title", "ingredients", "steps"]
       },
@@ -237,23 +272,15 @@
       },
       "Recipe": {
         "allOf": [
-          { "$ref": "#/components/schemas/RecipeSummary" },
+          { "$ref": "#/components/schemas/NormalizedRecipe" },
           {
             "type": "object",
             "properties": {
               "author": { "type": ["string", "null"] },
-              "description": { "type": ["string", "null"] },
-              "ingredients_json": {
-                "type": "array",
-                "items": { "type": "string" },
-                "description": "Ingredients serialized as JSON array"
-              },
-              "steps_json": {
-                "type": "array",
-                "items": { "type": "string" },
-                "description": "Preparation steps serialized as JSON array"
-              }
-            }
+              "createdAt": { "type": "string", "format": "date-time" },
+              "updatedAt": { "type": "string", "format": "date-time" }
+            },
+            "required": ["createdAt", "updatedAt"]
           }
         ]
       },
@@ -649,6 +676,84 @@
         }
       }
     },
+    "/api/recipes/{id}/flowchart": {
+      "get": {
+        "summary": "Generate a Mermaid flowchart for a recipe",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Mermaid definition",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "flowchart": { "type": "string" }
+                  },
+                  "required": ["flowchart"]
+                }
+              }
+            }
+          },
+          "404": { "description": "Recipe not found" }
+        }
+      }
+    },
+    "/api/recipes/{id}/tailor": {
+      "post": {
+        "summary": "Tailor recipe instructions for a specific appliance",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "appliance_id": { "type": "string" }
+                },
+                "required": ["appliance_id"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Tailored recipe instructions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "tailored_steps": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  },
+                  "required": ["tailored_steps"]
+                }
+              }
+            }
+          },
+          "404": { "description": "Recipe or appliance not found" },
+          "409": { "description": "Appliance manual not processed" }
+        }
+      }
+    },
     "/api/recipes/{id}/rating": {
       "get": {
         "summary": "Get the current user's rating",
@@ -939,6 +1044,95 @@
               }
             }
           }
+        }
+      }
+    },
+    "/api/kitchen/appliances": {
+      "post": {
+        "summary": "Register a kitchen appliance and optional manual",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "brand": { "type": "string" },
+                  "model": { "type": "string" },
+                  "manual": { "type": "string", "format": "binary" }
+                },
+                "required": ["brand", "model"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Appliance created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "appliance": { "$ref": "#/components/schemas/KitchenAppliance" }
+                  },
+                  "required": ["appliance"]
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "summary": "List kitchen appliances for the authenticated user",
+        "responses": {
+          "200": {
+            "description": "Appliance listing",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "appliances": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/KitchenAppliance" }
+                    }
+                  },
+                  "required": ["appliances"]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kitchen/appliances/{id}": {
+      "delete": {
+        "summary": "Remove a kitchen appliance",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deletion confirmation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" }
+                  },
+                  "required": ["success"]
+                }
+              }
+            }
+          },
+          "404": { "description": "Appliance not found" }
         }
       }
     },

--- a/src/env.ts
+++ b/src/env.ts
@@ -35,6 +35,48 @@ export interface VectorizeIndex {
     returnValues?: boolean;
     returnMetadata?: boolean;
   }): Promise<VectorizeQueryResult>;
+  delete?(ids: string[]): Promise<unknown>;
+}
+
+export type R2Body =
+  | ArrayBuffer
+  | ArrayBufferView
+  | ReadableStream
+  | Blob
+  | string
+  | null;
+
+export interface R2ObjectBody {
+  body?: ReadableStream;
+  text(): Promise<string>;
+  json<T = unknown>(): Promise<T>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export interface R2Object {
+  key: string;
+  size: number;
+  uploaded: string;
+  httpEtag?: string;
+  httpMetadata?: Record<string, unknown>;
+  customMetadata?: Record<string, string>;
+  body?: ReadableStream;
+  writeHttpMetadata(response: ResponseInit): void;
+  readHttpMetadata(): Record<string, unknown>;
+  text(): Promise<string>;
+  json<T = unknown>(): Promise<T>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export interface R2PutOptions {
+  httpMetadata?: { contentType?: string };
+  customMetadata?: Record<string, string>;
+}
+
+export interface R2Bucket {
+  put(key: string, value: R2Body, options?: R2PutOptions): Promise<void | R2Object>;
+  get(key: string): Promise<R2Object | null>;
+  delete(key: string): Promise<void>;
 }
 
 export interface BrowserPage {
@@ -61,4 +103,5 @@ export interface Env {
   BROWSER: BrowserService;
   VEC: VectorizeIndex;
   KV: KVNamespace;
+  BUCKET: R2Bucket;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,10 +9,16 @@ export interface RecipeStep {
   instruction: string;
 }
 
+export interface PrepPhase {
+  phaseTitle: string;
+  ingredients: Ingredient[];
+}
+
 export interface NormalizedRecipe {
   id: string;
   title: string;
   description?: string;
+  author?: string | null;
   cuisine?: string;
   tags?: string[];
   heroImageUrl?: string;
@@ -25,6 +31,12 @@ export interface NormalizedRecipe {
   tools?: string[];
   notes?: string;
   sourceUrl?: string;
+  prepPhases?: PrepPhase[];
+}
+
+export interface RecipeDetail extends NormalizedRecipe {
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface RecipeSummary {
@@ -127,4 +139,16 @@ export interface ShoppingListItem {
   quantity?: string | null;
   unit?: string | null;
   isChecked: boolean;
+}
+
+export interface KitchenAppliance {
+  id: string;
+  userId: string;
+  brand: string;
+  model: string;
+  manualR2Key?: string | null;
+  extractedText?: string | null;
+  manualEmbedding?: number[] | null;
+  createdAt: string;
+  updatedAt: string;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1178,7 +1178,7 @@ app.post('/api/recipes/:id/tailor', async (c) => {
     return jsonResponse({ error: 'appliance manual has not been processed yet' }, { status: 409 });
   }
 
-  const originalSteps = recipe.steps.map((step) => step.instruction || String(step));
+  const originalSteps = recipe.steps.map((step) => step.instruction);
 
   try {
     const tailoredSteps = await tailorRecipeInstructions(c.env, {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -6,15 +6,21 @@ import { ensureRecipeId, jsonResponse, parseArray, parseJsonBody, truncate } fro
 import {
   categorizeShoppingList,
   extractTextFromImage,
+  extractTextFromPdf,
   generateChatMessage,
+  generatePrepPhases,
+  generateRecipeFlowchart,
   generateMenuPlan,
+  tailorRecipeInstructions,
   normalizeRecipeFromText,
   transcribeAudio,
   embedText,
   MenuGenerationCandidate,
 } from './ai';
 import {
+  createKitchenAppliance,
   getUserPreferences,
+  getRecipeById,
   listRecipesByIds,
   recentThemeRecipes,
   storeIngestion,
@@ -30,8 +36,13 @@ import {
   updatePantryItem,
   deletePantryItem,
   getRecipesWithIngredients,
+  listKitchenAppliances,
+  updateRecipePrepPhases,
+  getKitchenAppliance,
+  updateKitchenApplianceManualData,
+  deleteKitchenAppliance,
 } from './db';
-import { MenuItem, RecipeSummary, UserPreferences } from './types';
+import { MenuItem, RecipeDetail, RecipeSummary, UserPreferences } from './types';
 
 export const app = new Hono<{ Bindings: Env }>();
 
@@ -182,6 +193,41 @@ function normalizeIngredientEntry(raw: unknown): { name: string; quantity?: stri
     return { name, quantity: quantity ?? undefined };
   }
   return null;
+}
+
+async function processApplianceManual(
+  env: Env,
+  input: { applianceId: string; manualKey?: string | null; pdfBytes: Uint8Array; brand: string; model: string }
+): Promise<void> {
+  try {
+    const extracted = await extractTextFromPdf(env, input.pdfBytes);
+    const cleaned = extracted.trim();
+    const truncated = cleaned ? truncate(cleaned, 50000) : '';
+    const embedding = truncated ? await embedText(env, truncated) : [];
+
+    await updateKitchenApplianceManualData(env, input.applianceId, {
+      extractedText: truncated || null,
+      manualEmbedding: embedding.length ? embedding : null,
+    });
+
+    if (embedding.length) {
+      await env.VEC.upsert([
+        {
+          id: `appliance:${input.applianceId}`,
+          values: embedding,
+          metadata: {
+            type: 'appliance_manual',
+            appliance_id: input.applianceId,
+            manual_r2_key: input.manualKey ?? undefined,
+            brand: input.brand,
+            model: input.model,
+          },
+        },
+      ]);
+    }
+  } catch (error) {
+    console.error('Failed to process appliance manual', input.applianceId, error);
+  }
 }
 
 // API Routes from codex/add-ai-chat-and-ingestion-features
@@ -418,6 +464,8 @@ export async function handlePutPrefs(c: any): Promise<Response> {
     cuisines?: unknown;
     dislikedIngredients?: unknown;
     favoredTools?: unknown;
+    dietaryRestrictions?: unknown;
+    allergies?: unknown;
     notes?: unknown;
   }>(c.req.raw);
 
@@ -631,6 +679,132 @@ app.post('/api/menus/generate', async (c) => {
     week_start: weekStart,
     items: responseItems,
   });
+});
+
+app.post('/api/kitchen/appliances', async (c) => {
+  const userId = await requireUserId(c);
+  if (!userId) {
+    return jsonResponse({ error: 'authentication required' }, { status: 401 });
+  }
+
+  let form: FormData;
+  try {
+    form = await c.req.raw.formData();
+  } catch (error) {
+    return jsonResponse({ error: 'invalid form data' }, { status: 400 });
+  }
+
+  const brandValue = form.get('brand');
+  const modelValue = form.get('model');
+  const manualValue = form.get('manual');
+
+  if (typeof brandValue !== 'string' || !brandValue.trim()) {
+    return jsonResponse({ error: 'brand is required' }, { status: 400 });
+  }
+  if (typeof modelValue !== 'string' || !modelValue.trim()) {
+    return jsonResponse({ error: 'model is required' }, { status: 400 });
+  }
+
+  let manualFile: File | null = null;
+  if (manualValue != null) {
+    if (manualValue instanceof File) {
+      manualFile = manualValue;
+    } else {
+      return jsonResponse({ error: 'manual must be a file upload' }, { status: 400 });
+    }
+  }
+
+  const brand = brandValue.trim();
+  const model = modelValue.trim();
+  const applianceId = crypto.randomUUID();
+  let manualKey: string | null = null;
+  let manualBytes: Uint8Array | null = null;
+
+  if (manualFile) {
+    try {
+      const arrayBuffer = await manualFile.arrayBuffer();
+      manualBytes = new Uint8Array(arrayBuffer);
+      const extensionMatch = manualFile.name?.match(/\.([a-z0-9]+)$/i);
+      const extension = extensionMatch ? `.${extensionMatch[1].toLowerCase()}` : '.pdf';
+      manualKey = `kitchen-manuals/${userId}/${applianceId}${extension}`;
+      await c.env.BUCKET.put(manualKey, manualBytes, {
+        httpMetadata: { contentType: manualFile.type || 'application/pdf' },
+      });
+    } catch (error) {
+      console.error('Failed to store manual in R2', error);
+      return jsonResponse({ error: 'failed to store manual' }, { status: 500 });
+    }
+  }
+
+  const appliance = await createKitchenAppliance(c.env, {
+    id: applianceId,
+    userId,
+    brand,
+    model,
+    manualR2Key: manualKey,
+  });
+
+  if (manualBytes) {
+    const bytesCopy = new Uint8Array(manualBytes);
+    c.executionCtx.waitUntil(
+      processApplianceManual(c.env, {
+        applianceId,
+        manualKey,
+        pdfBytes: bytesCopy,
+        brand,
+        model,
+      })
+    );
+  }
+
+  return jsonResponse({ appliance }, { status: 201 });
+});
+
+app.get('/api/kitchen/appliances', async (c) => {
+  const userId = await requireUserId(c);
+  if (!userId) {
+    return jsonResponse({ error: 'authentication required' }, { status: 401 });
+  }
+
+  const appliances = await listKitchenAppliances(c.env, userId);
+  return jsonResponse({ appliances });
+});
+
+app.delete('/api/kitchen/appliances/:id', async (c) => {
+  const userId = await requireUserId(c);
+  if (!userId) {
+    return jsonResponse({ error: 'authentication required' }, { status: 401 });
+  }
+
+  const id = c.req.param('id');
+  if (!id) {
+    return jsonResponse({ error: 'appliance id required' }, { status: 400 });
+  }
+
+  const appliance = await getKitchenAppliance(c.env, id);
+  if (!appliance || appliance.userId !== userId) {
+    return jsonResponse({ error: 'appliance not found' }, { status: 404 });
+  }
+
+  if (appliance.manualR2Key) {
+    try {
+      await c.env.BUCKET.delete(appliance.manualR2Key);
+    } catch (error) {
+      console.warn('Failed to delete manual from R2', error);
+    }
+  }
+
+  await deleteKitchenAppliance(c.env, userId, id);
+
+  if (typeof c.env.VEC.delete === 'function') {
+    try {
+      await c.env.VEC.delete([`appliance:${id}`]);
+    } catch (error) {
+      console.warn('Failed to delete appliance vector entry', error);
+    }
+  }
+
+  return jsonResponse({ success: true });
 });
 
 app.get('/api/pantry', async (c) => {
@@ -906,6 +1080,120 @@ app.get('/api/recipes', async (c) => {
   } catch (error) {
     console.error('List recipes error:', error);
     return c.json({ error: 'Failed to list recipes' }, 500);
+  }
+});
+
+app.get('/api/recipes/:id', async (c) => {
+  try {
+    const id = c.req.param('id');
+    if (!id) {
+      return jsonResponse({ error: 'recipe id required' }, { status: 400 });
+    }
+
+    let recipe = await getRecipeById(c.env, id);
+    if (!recipe) {
+      return jsonResponse({ error: 'recipe not found' }, { status: 404 });
+    }
+
+    if ((!recipe.prepPhases || recipe.prepPhases.length === 0) && recipe.ingredients.length && recipe.steps.length) {
+      try {
+        const phases = await generatePrepPhases(c.env, recipe);
+        if (phases.length) {
+          await updateRecipePrepPhases(c.env, recipe.id, phases);
+        }
+        recipe = { ...recipe, prepPhases: phases } as RecipeDetail;
+      } catch (error) {
+        console.warn('Failed to generate prep phases on-demand', error);
+      }
+    }
+
+    return jsonResponse({ recipe });
+  } catch (error) {
+    console.error('Recipe detail error', error);
+    return jsonResponse({ error: 'failed to load recipe' }, { status: 500 });
+  }
+});
+
+app.get('/api/recipes/:id/flowchart', async (c) => {
+  const id = c.req.param('id');
+  if (!id) {
+    return jsonResponse({ error: 'recipe id required' }, { status: 400 });
+  }
+
+  const recipe = await getRecipeById(c.env, id);
+  if (!recipe) {
+    return jsonResponse({ error: 'recipe not found' }, { status: 404 });
+  }
+
+  try {
+    const flowchart = await generateRecipeFlowchart(c.env, {
+      title: recipe.title,
+      steps: recipe.steps,
+      prepTimeMinutes: recipe.prepTimeMinutes,
+      cookTimeMinutes: recipe.cookTimeMinutes,
+      totalTimeMinutes: recipe.totalTimeMinutes,
+    });
+    return jsonResponse({ flowchart });
+  } catch (error) {
+    console.error('Failed to generate flowchart', error);
+    return jsonResponse({ error: 'failed to generate flowchart' }, { status: 500 });
+  }
+});
+
+app.post('/api/recipes/:id/tailor', async (c) => {
+  const userId = await requireUserId(c);
+  if (!userId) {
+    return jsonResponse({ error: 'authentication required' }, { status: 401 });
+  }
+
+  const id = c.req.param('id');
+  if (!id) {
+    return jsonResponse({ error: 'recipe id required' }, { status: 400 });
+  }
+
+  let body: { appliance_id?: unknown };
+  try {
+    body = await parseJsonBody<typeof body>(c.req.raw);
+  } catch (error: any) {
+    const status = typeof error?.status === 'number' ? error.status : 400;
+    return jsonResponse({ error: error?.message ?? 'invalid JSON body' }, { status });
+  }
+
+  const applianceId = typeof body.appliance_id === 'string' ? body.appliance_id.trim() : '';
+  if (!applianceId) {
+    return jsonResponse({ error: 'appliance_id is required' }, { status: 400 });
+  }
+
+  const recipe = await getRecipeById(c.env, id);
+  if (!recipe) {
+    return jsonResponse({ error: 'recipe not found' }, { status: 404 });
+  }
+
+  const appliance = await getKitchenAppliance(c.env, applianceId);
+  if (!appliance || appliance.userId !== userId) {
+    return jsonResponse({ error: 'appliance not found' }, { status: 404 });
+  }
+
+  if (!appliance.extractedText) {
+    return jsonResponse({ error: 'appliance manual has not been processed yet' }, { status: 409 });
+  }
+
+  const originalSteps = recipe.steps.map((step) => step.instruction || String(step));
+
+  try {
+    const tailoredSteps = await tailorRecipeInstructions(c.env, {
+      title: recipe.title,
+      originalSteps,
+      manualText: appliance.extractedText,
+      appliance: { brand: appliance.brand, model: appliance.model },
+      prepPhases: recipe.prepPhases,
+      manualEmbedding: appliance.manualEmbedding ?? null,
+    });
+
+    return jsonResponse({ tailored_steps: tailoredSteps });
+  } catch (error) {
+    console.error('Failed to tailor recipe', error);
+    return jsonResponse({ error: 'failed to tailor recipe' }, { status: 500 });
   }
 });
 


### PR DESCRIPTION
## Summary
- add a kitchen_appliances table with routes to upload manuals, trigger OCR/embeddings, list, and delete appliances
- generate recipe prep phases, flowchart mermaid definitions, and appliance-tailored instructions with new AI helpers and API endpoints
- refresh the docs, UI, and tests to cover the new functionality

## Testing
- npm run typecheck
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e04a0c2234832eb2fc70745dd9621c