### PR TITLE
Add migration for crawl queue table

### DIFF
--- a/migrations/0005_crawl_queue.sql
+++ b/migrations/0005_crawl_queue.sql
@@ -1,0 +1,13 @@
+-- Migration: Add crawl_queue table for scheduled scraping pipeline
+CREATE TABLE IF NOT EXISTS crawl_queue (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  url TEXT NOT NULL UNIQUE,
+  status TEXT NOT NULL DEFAULT 'queued',
+  priority INTEGER NOT NULL DEFAULT 0,
+  error TEXT,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_crawl_queue_status_priority
+  ON crawl_queue (status, priority DESC, created_at);


### PR DESCRIPTION
## Summary
- add a D1 migration that creates the crawl_queue table and supporting index

## Testing
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e09b3b8c18832eac60d3bcf3f6e98d