### PR TITLE
Add migration to ensure request_logs table exists

### DIFF
--- a/migrations/0006_request_logs_table.sql
+++ b/migrations/0006_request_logs_table.sql
@@ -1,0 +1,18 @@
+-- Migration: Ensure request_logs table exists for observability
+-- Context: Production error `D1_ERROR: no such table: request_logs` indicates
+--          some environments were initialized without this table. This
+--          migration recreates the table definition defensively so new or
+--          existing databases regain logging capabilities without destructive
+--          resets.
+
+CREATE TABLE IF NOT EXISTS request_logs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts TEXT NOT NULL,
+  level TEXT NOT NULL,
+  route TEXT NOT NULL,
+  method TEXT NOT NULL,
+  status INTEGER NOT NULL,
+  ms INTEGER NOT NULL,
+  msg TEXT,
+  meta TEXT
+);


### PR DESCRIPTION
## Summary
- add a defensive migration that creates the `request_logs` table when missing to restore observability after deployment issues

## Testing
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e09d06b714832ebeed1888cfcf8b82